### PR TITLE
Reset raytrace accumulation when TLAS changes

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -543,6 +543,7 @@ void R_NewGame (void);
 
 void R_AnimateLight (void);
 void R_BuildTopLevelAccelerationStructure (void *unused);
+uint32_t R_BModelTLASRevision (void);
 void R_UpdateLightmapsAndIndirect (void *unused);
 void R_MarkSurfaces (qboolean use_tasks, task_handle_t before_mark, task_handle_t *store_efrags, task_handle_t *cull_surfaces, task_handle_t *chain_surfaces);
 qboolean R_CullBox (vec3_t emins, vec3_t emaxs);


### PR DESCRIPTION
## Summary
- track a TLAS revision hash when building and destroying the ray tracing acceleration structure
- expose the TLAS revision to the renderer and reset the accumulation buffer when the TLAS content changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e19932e33c8324a7e570ccd9a7f3be